### PR TITLE
Enable array reading in ResultCollection

### DIFF
--- a/job/results.py
+++ b/job/results.py
@@ -501,6 +501,8 @@ class ResultCollection(List[Result]):
                 for key, value in result.result.items():
                     if np.isscalar(value):
                         data[key] = value
+                    elif isinstance(value, list) or isinstance(value, np.ndarray):
+                        data[key] = np.asarray(value)
             else:
                 raise RuntimeError("Do not know how to interpret result")
             return data


### PR DESCRIPTION
In previous result.dataframe method, only single valued result could be read.
This commit tries to enable arrays and lists reading in result files.