### PR TITLE
Revert change of file mode from "a+" to "x"

### DIFF
--- a/modelrunner/state/io.py
+++ b/modelrunner/state/io.py
@@ -301,7 +301,7 @@ class IOBase:
                 writing of the specific format (_write_**).
         """
         fmt = self._guess_format(store, fmt)
-        mode = "w" if overwrite else "a+"
+        mode = "w" if overwrite else "x"  # zarr.ZipStore does only supports r, w, a, x
 
         if fmt == "json":
             content = simplify_data(self._to_simple_objects())


### PR DESCRIPTION
zarr.ZipStore does not support a+

This reverts a change made in #40 