### PR TITLE
Set thread count in submission script

### DIFF
--- a/modelrunner/run/job.py
+++ b/modelrunner/run/job.py
@@ -121,7 +121,7 @@ def submit_job(
     # prepare submission script
     ensure_directory_exists(log_folder)
 
-    script_args = {
+    script_args: Dict[str, Any] = {
         "PACKAGE_PATH": Path(__file__).parents[2],
         "LOG_FOLDER": log_folder,
         "JOB_NAME": name,
@@ -177,6 +177,9 @@ def submit_job(
         # if `output` is not specified, save data to current directory
         script_args["OUTPUT_FOLDER"] = "."
     script_args["JOB_ARGS"] = " ".join(job_args)
+
+    # set some default values if no values have been specified
+    script_args["NUM_THREADS"] = 1
 
     # replace parameters in submission script template
     script_content = Template(script_template).render(script_args)

--- a/modelrunner/run/templates/background.template
+++ b/modelrunner/run/templates/background.template
@@ -2,6 +2,15 @@
 
 export PYTHONPATH={{ PACKAGE_PATH }}:$PYTHONPATH
 
+{% if NUM_THREADS is number %}
+# set the number of threads to use
+export MKL_NUM_THREADS={NUM_THREADS}
+export NUMBA_NUM_THREADS={NUM_THREADS}
+export NUMEXPR_NUM_THREADS={NUM_THREADS}
+export OMP_NUM_THREADS={NUM_THREADS}
+export OPENBLAS_NUM_THREADS={NUM_THREADS}
+{% endif %}
+
 {% if OUTPUT_FOLDER is defined and OUTPUT_FOLDER %}
 mkdir -p {{ OUTPUT_FOLDER }}
 {% endif %}

--- a/modelrunner/run/templates/foreground.template
+++ b/modelrunner/run/templates/foreground.template
@@ -2,6 +2,15 @@
 
 export PYTHONPATH={{ PACKAGE_PATH }}:$PYTHONPATH
 
+{% if NUM_THREADS is number %}
+# set the number of threads to use
+export MKL_NUM_THREADS={NUM_THREADS}
+export NUMBA_NUM_THREADS={NUM_THREADS}
+export NUMEXPR_NUM_THREADS={NUM_THREADS}
+export OMP_NUM_THREADS={NUM_THREADS}
+export OPENBLAS_NUM_THREADS={NUM_THREADS}
+{% endif %}
+
 {% if OUTPUT_FOLDER is defined and OUTPUT_FOLDER %}
 mkdir -p {{ OUTPUT_FOLDER }}
 {% endif %}

--- a/modelrunner/run/templates/qsub.template
+++ b/modelrunner/run/templates/qsub.template
@@ -20,6 +20,15 @@
 hostname
 echo $JOB_ID
 
+{% if NUM_THREADS is number %}
+# set the number of threads to use
+export MKL_NUM_THREADS={NUM_THREADS}
+export NUMBA_NUM_THREADS={NUM_THREADS}
+export NUMEXPR_NUM_THREADS={NUM_THREADS}
+export OMP_NUM_THREADS={NUM_THREADS}
+export OPENBLAS_NUM_THREADS={NUM_THREADS}
+{% endif %}
+
 {% if OUTPUT_FOLDER is defined and OUTPUT_FOLDER %}
 mkdir -p {{ OUTPUT_FOLDER }}
 {% endif %}

--- a/modelrunner/run/templates/srun.template
+++ b/modelrunner/run/templates/srun.template
@@ -18,6 +18,15 @@
 hostname
 echo $JOB_ID
 
+{% if NUM_THREADS is number %}
+# set the number of threads to use
+export MKL_NUM_THREADS={NUM_THREADS}
+export NUMBA_NUM_THREADS={NUM_THREADS}
+export NUMEXPR_NUM_THREADS={NUM_THREADS}
+export OMP_NUM_THREADS={NUM_THREADS}
+export OPENBLAS_NUM_THREADS={NUM_THREADS}
+{% endif %}
+
 {% if OUTPUT_FOLDER is defined and OUTPUT_FOLDER %}
 mkdir -p {{ OUTPUT_FOLDER }}
 {% endif %}


### PR DESCRIPTION
* Added new option `num_threads` to control thread count. If this is set to a number, the submission script sets the thread count to this number. If this is a string, the submission script does not add any statements for controlling the treadcount. The default value is `1`, limiting code to a single thread, which is desirable in typical HPC environments.
* This branch also cleaned up some test to delete their4 files after testing